### PR TITLE
Implement XML saída import

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,10 +12,11 @@ def menu():
         print("\n== Sistema de Estoque ==")
         print("1. Ver estoque")
         print("2. Importar XML de Entrada")
-        print("3. Buscar produtos com filtros")
-        print("4. Excluir produto por código")
-        print("5. Exportar estoque para Excel")
-        print("6. Sair")
+        print("3. Importar XML de Saída")
+        print("4. Buscar produtos com filtros")
+        print("5. Excluir produto por código")
+        print("6. Exportar estoque para Excel")
+        print("7. Sair")
 
         opcao = input("Escolha uma opção: ")
 
@@ -29,18 +30,23 @@ def menu():
             importar_xml(caminho)
 
         elif opcao == "3":
-            aplicar_filtros()
+            nome_arquivo = input("Digite o nome do arquivo XML de saída (dentro da pasta 'xmls/'): ")
+            caminho = os.path.join("xmls", nome_arquivo)
+            importar_saida_xml(caminho)
 
         elif opcao == "4":
+            aplicar_filtros()
+
+        elif opcao == "5":
             codigo = input("Digite o código do produto que deseja excluir: ").strip()
             excluir_produto_por_codigo(codigo)
             print(f"Produto com código {codigo} excluído (se existia).")
 
-        elif opcao == "5":
+        elif opcao == "6":
             produtos = listar_estoque()
             exportar_estoque_excel(produtos)
 
-        elif opcao == "6":
+        elif opcao == "7":
             print("Encerrando o sistema.")
             break
 

--- a/services/xml_service.py
+++ b/services/xml_service.py
@@ -64,3 +64,49 @@ def importar_xml(caminho):
     historico.append(hash_arquivo)
     salvar_historico(historico)
     print("Importação concluída com sucesso.")
+
+
+def importar_saida_xml(caminho):
+    """Importa um XML de saída e subtrai as quantidades do estoque."""
+    if not os.path.exists(caminho):
+        print("Arquivo não encontrado.")
+        return
+
+    hash_arquivo = gerar_hash_arquivo(caminho)
+    historico = carregar_historico()
+
+    if hash_arquivo in historico:
+        print("Este XML já foi importado anteriormente. Ignorado.")
+        return
+
+    tree = ET.parse(caminho)
+    root = tree.getroot()
+    ns = {'nfe': 'http://www.portalfiscal.inf.br/nfe'}
+
+    cliente = root.find(".//nfe:dest/nfe:xNome", ns)
+    cliente_nome = cliente.text if cliente is not None else "Desconhecido"
+
+    for det in root.findall(".//nfe:det", ns):
+        prod = det.find("nfe:prod", ns)
+        if prod is None:
+            continue
+
+        codigo = prod.find("nfe:cProd", ns).text
+        nome = prod.find("nfe:xProd", ns).text
+        quantidade = float(prod.find("nfe:qCom", ns).text)
+        preco = float(prod.find("nfe:vUnCom", ns).text)
+
+        produto = Produto(
+            codigo=codigo,
+            nome=nome,
+            quantidade=int(quantidade),
+            preco=preco,
+            fornecedor=cliente_nome,
+            estoque_minimo=0,
+        )
+
+        atualizar_estoque(produto, tipo="saida")
+
+    historico.append(hash_arquivo)
+    salvar_historico(historico)
+    print("Importação concluída com sucesso.")


### PR DESCRIPTION
## Summary
- add `importar_saida_xml` to parse NF-e XMLs de saída and subtract from stock
- extend menu with new option to import XML de saída

## Testing
- `python -m py_compile main.py services/xml_service.py controllers/estoque_controller.py models/produto.py teste_import.py`
- `python teste_import.py`

------
https://chatgpt.com/codex/tasks/task_e_685b3a105b50832ba8166be6f5a98742